### PR TITLE
Create a docker-based build.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,15 @@
+FROM base/archlinux
+
+RUN pacman --sync --refresh --noconfirm --noprogressbar --quiet
+RUN pacman --sync --noconfirm --noprogressbar --quiet php xdebug php-mongo git openssh
+
+ADD provisioning/php/php-extensions.ini /etc/php/conf.d/extensions.ini
+ADD provisioning/php/xdebug.ini /etc/php/conf.d/xdebug.ini
+ADD provisioning/set-env.sh /set-env.sh
+
+RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
+
+VOLUME ["/code"]
+
+ENTRYPOINT ["/set-env.sh"]
+CMD ["/code/build.php"]

--- a/dockerBuild.php
+++ b/dockerBuild.php
@@ -1,0 +1,29 @@
+#!/usr/bin/env php
+<?php
+$returnStatus = null;
+passthru('docker build --tag=mongo-queue-php ' . __DIR__, $returnStatus);
+if ($returnStatus !== 0) {
+    exit(1);
+}
+
+passthru(
+    'docker run --name mongo-queue-php-build --tty --rm --volume ' . __DIR__ . ':/code ' . createLink('mongo') . ' mongo-queue-php',
+    $returnStatus
+);
+if ($returnStatus !== 0) {
+    exit(1);
+}
+
+function createLink($name)
+{
+    $returnStatus = null;
+    passthru("docker inspect --format='{{.Name}}' mongo-queue-php-{$name}", $returnStatus);
+    if ($returnStatus !== 0) {
+        passthru("docker run --name mongo-queue-php-{$name} --detach {$name}", $returnStatus);
+        if ($returnStatus !== 0) {
+            exit(1);
+        }
+    }
+
+    return "--link mongo-queue-php-{$name}:{$name}";
+}

--- a/provisioning/php/php-extensions.ini
+++ b/provisioning/php/php-extensions.ini
@@ -1,0 +1,9 @@
+[PHP]
+open_basedir =
+
+extension = openssl.so
+extension = phar.so
+extension = zip.so
+
+[Date]
+date.timezone = America/New_York

--- a/provisioning/php/xdebug.ini
+++ b/provisioning/php/xdebug.ini
@@ -1,0 +1,1 @@
+zend_extension=/usr/lib/php/modules/xdebug.so

--- a/provisioning/set-env.sh
+++ b/provisioning/set-env.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+if test -z "${MONGO_PORT_27017_TCP_ADDR}" -o -z "${MONGO_PORT_27017_TCP_PORT}"; then
+    echo "You must link this container with mongo first"
+    exit 1
+fi
+
+export TESTING_MONGO_URL="mongodb://${MONGO_PORT_27017_TCP_ADDR}:${MONGO_PORT_27017_TCP_PORT}"
+
+# See http://tldp.org/LDP/abs/html/devref1.html for description of this syntax.
+while ! exec 6<>/dev/tcp/${MONGO_PORT_27017_TCP_ADDR}/${MONGO_PORT_27017_TCP_PORT}; do
+    echo "$(date) - still trying to connect to mongo at ${TESTING_MONGO_URL}"
+    sleep 1
+done
+
+exec 6>&-
+exec 6<&-
+
+$@

--- a/tests/QueueTest.php
+++ b/tests/QueueTest.php
@@ -9,15 +9,17 @@ namespace DominionEnterprises\Mongo;
 final class QueueTest extends \PHPUnit_Framework_TestCase
 {
     private $_collection;
+    private $_mongoUrl;
     private $_queue;
 
     public function setUp()
     {
-        $mongo = new \MongoClient('mongodb://localhost');
+        $this->_mongoUrl = getenv('TESTING_MONGO_URL') ?: 'mongodb://localhost:27017';
+        $mongo = new \MongoClient($this->_mongoUrl);
         $this->_collection = $mongo->selectDB('testing')->selectCollection('messages');
         $this->_collection->drop();
 
-        $this->_queue = new Queue('mongodb://localhost', 'testing', 'messages');
+        $this->_queue = new Queue($this->_mongoUrl, 'testing', 'messages');
     }
 
     /**
@@ -37,7 +39,7 @@ final class QueueTest extends \PHPUnit_Framework_TestCase
      */
     public function constructWithNonStringDb()
     {
-        new Queue('mongodb://localhost', true, 'messages');
+        new Queue($this->_mongoUrl, true, 'messages');
     }
 
     /**
@@ -47,7 +49,7 @@ final class QueueTest extends \PHPUnit_Framework_TestCase
      */
     public function constructWithNonStringCollection()
     {
-        new Queue('mongodb://localhost', 'testing', new \stdClass());
+        new Queue($this->_mongoUrl, 'testing', new \stdClass());
     }
 
     /**
@@ -84,7 +86,7 @@ final class QueueTest extends \PHPUnit_Framework_TestCase
         $collectionName = 'messages012345678901234567890123456789012345678901234567890123456789';
         $collectionName .= '012345678901234567890123456789012345678901234567890123456789';//128 chars
 
-        $queue = new Queue('mongodb://localhost', 'testing', $collectionName);
+        $queue = new Queue($this->_mongoUrl, 'testing', $collectionName);
         $queue->ensureGetIndex(array());
     }
 


### PR DESCRIPTION
This helps make it easier to run this build by removing the necessity to
setup and run a local mongo server.
