### PR TITLE
Sync and install packages in same command.

### DIFF
--- a/tests/Dockerfile
+++ b/tests/Dockerfile
@@ -2,8 +2,7 @@ FROM nubs/phpunit
 
 USER root
 
-RUN pacman --sync --refresh --noconfirm --noprogressbar --quiet
-RUN pacman --sync --noconfirm --noprogressbar --quiet php-mongo
+RUN pacman --sync --refresh --noconfirm --noprogressbar --quiet && pacman --sync --noconfirm --noprogressbar --quiet php-mongo
 
 # Get around a bug with docker registry where the owner is root for the home
 # user.  See https://github.com/docker/docker/issues/5892.


### PR DESCRIPTION
This helps keep the docker cache from interfering with repeated builds.
