### PR TITLE
Fix deprecation notice about implicit cast of floats.

### DIFF
--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-18.04
     strategy:
       matrix:
-        php-versions: ['7.2', '7.3', '7.4', '8.0', '8.1']
+        php-versions: ['7.2', '7.3', '7.4', '8.0', '8.1', '8.2']
     steps:
     - name: Checkout
       uses: actions/checkout@v2

--- a/src/AbstractQueue.php
+++ b/src/AbstractQueue.php
@@ -408,9 +408,8 @@ abstract class AbstractQueue
         }
     }
 
-    private function calculateEndTime(int $waitDurationInMillis) : int
+    private function calculateEndTime(int $waitDurationInMillis) : float
     {
-        //ints overflow to floats, should be fine
         return microtime(true) + ($waitDurationInMillis / 1000.0);
     }
 }


### PR DESCRIPTION
Fixes #69.

#### What does this PR do?
Change method return type to stop deprecation notice about implicit float conversion.

#### Checklist
- [ ] Pull request contains a clear definition of changes
- [ ] Tests (either unit, integration, or acceptance) written and passing
- [ ] Relevant documentation produced and/or updated
